### PR TITLE
Media Module implementation with JSON persistence and artisan commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+storage/media.json

--- a/README.md
+++ b/README.md
@@ -1,66 +1,147 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Modular CMS (PHP Backend Challenge)
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+This project is a modular PHP backend component built with **Laravel 10**.  
+It simulates a **Media Management Module** for a future CMS, with support for media storage, metadata enrichment, and search capabilities.  
 
-## About Laravel
+---
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+## 🚀 Requirements
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+- PHP 8.2+  
+- Composer  
+- SQLite or JSON file storage (we are using JSON persistence for this challenge)  
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+Recommended extras:
+- [Intelephense VSCode Extension](https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client) for autocompletion.
+- [PHPStan](https://phpstan.org/) for static analysis.
 
-## Learning Laravel
+---
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+## 🔧 Installation
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+Clone the repository:
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+```bash
+git clone git@github.com:tatooin6/modular-cms.git
+cd modular-cms
+````
 
-## Laravel Sponsors
+Install dependencies:
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+```bash
+composer install
+```
 
-### Premium Partners
+Generate Laravel application key:
 
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[WebReinvent](https://webreinvent.com/)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel/)**
-- **[Cyber-Duck](https://cyber-duck.co.uk)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Jump24](https://jump24.co.uk)**
-- **[Redberry](https://redberry.international/laravel/)**
-- **[Active Logic](https://activelogic.com)**
-- **[byte5](https://byte5.de)**
-- **[OP.GG](https://op.gg)**
+```bash
+php artisan key:generate
+```
 
-## Contributing
+---
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+## ▶️ Running the Application
 
-## Code of Conduct
+We are not using HTTP routes or controllers.
+Instead, all interaction is done via **Artisan commands** in the CLI.
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+Laravel’s built-in commands work as usual, e.g.:
 
-## Security Vulnerabilities
+```bash
+php artisan about
+php artisan list
+```
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+---
 
-## License
+## 📦 Media Module Commands
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+### 1. Upload a new media
+
+```bash
+php artisan media:upload image "Logo" "Company logo" "http://example.com/logo.png"
+```
+
+Output:
+
+```
+Media successfully created:
+UUID: <uuid>
+Type: image
+Title: Logo
+Description: Company logo
+URL: http://example.com/logo.png
+Date: 2025-09-21 23:15:42
+```
+
+The media entry is stored in `storage/media.json`.
+
+---
+
+### 2. Enrich media metadata
+
+```bash
+php artisan media:enrich <uuid> width=1920 height=1080 format=png
+```
+
+Output:
+
+```
+Metadata enriched successfully:
+width: 1920
+height: 1080
+format: png
+```
+
+---
+
+### 3. Search media
+
+#### By type:
+
+```bash
+php artisan media:search --type=image
+```
+
+#### By title (partial match):
+
+```bash
+php artisan media:search --title=Logo
+```
+
+Output:
+
+```
+-------------------------
+UUID: <uuid>
+Type: image
+Title: Logo
+Description: Company logo
+URL: http://example.com/logo.png
+Date: 2025-09-21 23:15:42
+Metadata: {"width":"1920","height":"1080","format":"png"}
+```
+
+---
+
+## 📂 Project Structure
+
+```
+app/
+ ┣ Console/Commands/   # Artisan commands
+ ┣ Entities/           # Plain entities (POPOs)
+ ┣ Interfaces/         # Interfaces for repositories
+ ┣ Repositories/       # FileMediaRepository, InMemoryMediaRepository
+ ┗ Services/           # MediaService, MediaMetadataService
+```
+
+---
+
+## 🧪 Tests (coming soon)
+
+Unit tests will be located in `tests/Unit`.
+They will cover:
+
+* Media creation and validation
+* Metadata enrichment
+* Media resolution for articles

--- a/app/Console/Commands/EnrichMediaCommand.php
+++ b/app/Console/Commands/EnrichMediaCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Services\MediaService;
+use App\Services\MediaMetadataService;
+use App\Repositories\FileMediaRepository;
+
+
+class EnrichMediaCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'media:enrich 
+                            {uuid : UUID of the media} 
+                            {metadata* : Key=Value pairs of metadata (e.g. width=1920 height=1080)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enrich metadata of an existing media item';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $repo = new FileMediaRepository();
+        $mediaService = new MediaService($repo);
+        $metadataService = new MediaMetadataService($repo);
+
+        $uuid = $this->argument('uuid');
+        $metadataArgs = $this->argument('metadata');
+
+        // Parse key=value arguments into an array
+        $newMetadata = [];
+        foreach ($metadataArgs as $pair) {
+            [$key, $value] = explode('=', $pair, 2);
+            $newMetadata[$key] = $value;
+        }
+
+        $media = $metadataService->enrich($uuid, $newMetadata);
+
+        if (!$media) {
+            $this->error("Media not found with UUID: $uuid");
+            return;
+        }
+
+        $this->info("Metadata enriched successfully:");
+        foreach ($media->metadata as $key => $value) {
+            $this->line("$key: $value");
+        }
+    }
+}

--- a/app/Console/Commands/SearchMediaCommand.php
+++ b/app/Console/Commands/SearchMediaCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Services\MediaService;
+use App\Repositories\FileMediaRepository;
+
+class SearchMediaCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'media:search 
+                            {--type= : Search media by type (image, video, audio, graph, file)} 
+                            {--title= : Search media by title (partial match)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Search for media items by type or title';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $repo = new FileMediaRepository();
+        $service = new MediaService($repo);
+
+        $type = $this->option('type');
+        $title = $this->option('title');
+
+        if (!$type && !$title) {
+            $this->error("Please provide either --type or --title option.");
+            return;
+        }
+
+        $results = [];
+
+        if ($type) {
+            $results = $service->searchByType($type);
+        } elseif ($title) {
+            $results = $service->searchByTitle($title);
+        }
+
+        if (empty($results)) {
+            $this->warn("No media found for given criteria.");
+            return;
+        }
+
+        foreach ($results as $media) {
+            $this->line("-------------------------");
+            $this->line("UUID: {$media->uuid}");
+            $this->line("Type: {$media->type}");
+            $this->line("Title: {$media->title}");
+            $this->line("Description: {$media->description}");
+            $this->line("URL: {$media->sourceUrl}");
+            $this->line("Date: {$media->uploadedAt->format('Y-m-d H:i:s')}");
+            if (!empty($media->metadata)) {
+                $this->line("Metadata: " . json_encode($media->metadata));
+            }
+        }
+    }
+}

--- a/app/Console/Commands/UploadMediaCommand.php
+++ b/app/Console/Commands/UploadMediaCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Services\MediaService;
+use App\Repositories\FileMediaRepository;
+
+class UploadMediaCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'media:upload 
+                            {type : Media type (image, video, audio, graph, file)} 
+                            {title : Media title} 
+                            {description : Media description} 
+                            {sourceUrl : Source URL}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a media in the in-memory repository';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $repo = new FileMediaRepository();
+        $service = new MediaService($repo);
+
+        $media = $service->createMedia(
+            $this->argument('type'),
+            $this->argument('title'),
+            $this->argument('description'),
+            $this->argument('sourceUrl')
+        );
+
+        $this->info("Media successfully created:");
+        $this->line("UUID: {$media->uuid}");
+        $this->line("Type: {$media->type}");
+        $this->line("Title: {$media->title}");
+        $this->line("Description: {$media->description}");
+        $this->line("URL: {$media->sourceUrl}");
+        $this->line("Date: {$media->uploadedAt->format('Y-m-d H:i:s')}");
+    }
+}

--- a/app/Entities/Media.php
+++ b/app/Entities/Media.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Entities;
+
+use DateTimeImmutable;
+
+class Media
+{
+    public string $uuid;
+    public string $type;
+    public string $title;
+    public string $description;
+    public string $sourceUrl;
+    public DateTimeImmutable $uploadedAt;
+    public array $metadata;
+
+    public function __construct(
+        string $uuid,
+        string $type,
+        string $title,
+        string $description,
+        string $sourceUrl,
+        DateTimeImmutable $uploadedAt,
+        array $metadata = []
+    ) {
+        $this->uuid = $uuid;
+        $this->type = $type;
+        $this->title = $title;
+        $this->description = $description;
+        $this->sourceUrl = $sourceUrl;
+        $this->uploadedAt = $uploadedAt;
+        $this->metadata = $metadata;
+    }
+}

--- a/app/Interfaces/MediaRepositoryInterface.php
+++ b/app/Interfaces/MediaRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Interfaces;
+use App\Entities\Media;
+
+// Dependency Inversion
+// Services don't know the specific implementation (in memory, DB) only the interface.
+interface MediaRepositoryInterface
+{
+    public function save(Media $media): void;
+    public function findByUuid(string $uuid): ?Media;
+    public function findByType(string $type): array;
+    public function findByTitle(string $title): array;
+}

--- a/app/Repositories/FileMediaRepository.php
+++ b/app/Repositories/FileMediaRepository.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Entities\Media;
+use App\Interfaces\MediaRepositoryInterface;
+use DateTimeImmutable;
+
+class FileMediaRepository implements MediaRepositoryInterface
+{
+    private string $filePath;
+
+    public function __construct(string $filePath = 'storage/media.json')
+    {
+        $this->filePath = $filePath;
+
+        if (!file_exists($this->filePath)) {
+            file_put_contents($this->filePath, json_encode([]));
+        }
+    }
+
+    private function load(): array
+    {
+        $data = json_decode(file_get_contents($this->filePath), true);
+        return $data ?? [];
+    }
+
+    private function saveAll(array $data): void
+    {
+        file_put_contents($this->filePath, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    public function save(Media $media): void
+    {
+        $all = $this->load();
+        $all[$media->uuid] = [
+            'uuid' => $media->uuid,
+            'type' => $media->type,
+            'title' => $media->title,
+            'description' => $media->description,
+            'sourceUrl' => $media->sourceUrl,
+            'uploadedAt' => $media->uploadedAt->format(DateTimeImmutable::ATOM),
+            'metadata' => $media->metadata,
+        ];
+        $this->saveAll($all);
+    }
+
+    public function findByUuid(string $uuid): ?Media
+    {
+        $all = $this->load();
+        if (!isset($all[$uuid])) {
+            return null;
+        }
+
+        $item = $all[$uuid];
+        return new Media(
+            $item['uuid'],
+            $item['type'],
+            $item['title'],
+            $item['description'],
+            $item['sourceUrl'],
+            new DateTimeImmutable($item['uploadedAt']),
+            $item['metadata']
+        );
+    }
+
+    public function findByType(string $type): array
+    {
+        return array_values(array_filter(
+            array_map(fn($item) => new Media(
+                $item['uuid'],
+                $item['type'],
+                $item['title'],
+                $item['description'],
+                $item['sourceUrl'],
+                new DateTimeImmutable($item['uploadedAt']),
+                $item['metadata']
+            ), $this->load()),
+            fn(Media $m) => $m->type === $type
+        ));
+    }
+
+    public function findByTitle(string $title): array
+    {
+        return array_values(array_filter(
+            array_map(fn($item) => new Media(
+                $item['uuid'],
+                $item['type'],
+                $item['title'],
+                $item['description'],
+                $item['sourceUrl'],
+                new DateTimeImmutable($item['uploadedAt']),
+                $item['metadata']
+            ), $this->load()),
+            fn(Media $m) => stripos($m->title, $title) !== false
+        ));
+    }
+}

--- a/app/Repositories/InMemoryMediaRepository.php
+++ b/app/Repositories/InMemoryMediaRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Entities\Media;
+use App\Interfaces\MediaRepositoryInterface;
+
+/**
+ * Deprecated
+ */
+class InMemoryMediaRepository implements MediaRepositoryInterface
+{
+    private array $storage = [];
+
+    public function save(Media $media): void
+    {
+        $this->storage[$media->uuid] = $media;
+    }
+
+    public function findByUuid(string $uuid): ?Media
+    {
+        return $this->storage[$uuid] ?? null;
+    }
+
+    public function findByType(string $type): array
+    {
+        return array_values(
+            array_filter($this->storage, fn(Media $m) => $m->type === $type)
+        );
+    }
+
+    public function findByTitle(string $title): array
+    {
+        return array_values(
+            array_filter($this->storage, fn(Media $m) => stripos($m->title, $title) !== false)
+        );
+    }
+}

--- a/app/Services/MediaMetadataService.php
+++ b/app/Services/MediaMetadataService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use App\Entities\Media;
+use App\Interfaces\MediaRepositoryInterface;
+
+class MediaMetadataService
+{
+    private MediaRepositoryInterface $repository;
+
+    public function __construct(MediaRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function enrich(string $uuid, array $newMetadata): ?Media
+    {
+        $media = $this->repository->findByUuid($uuid);
+
+        if (!$media) {
+            return null;
+        }
+
+        $media->metadata = array_merge($media->metadata, $newMetadata);
+        $this->repository->save($media);
+
+        return $media;
+    }
+}

--- a/app/Services/MediaService.php
+++ b/app/Services/MediaService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services;
+
+use App\Entities\Media;
+use App\Interfaces\MediaRepositoryInterface;
+use DateTimeImmutable;
+use Ramsey\Uuid\Uuid;
+
+class MediaService
+{
+    private MediaRepositoryInterface $repository;
+    private array $allowedTypes = ['image', 'video', 'audio', 'graph', 'file']; // TODO: check if this can be enums
+
+    public function __construct(MediaRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function createMedia(
+        string $type,
+        string $title,
+        string $description,
+        string $sourceUrl,
+        array $metadata = []
+    ): Media {
+        if (!in_array($type, $this->allowedTypes, true)) {
+            throw new \InvalidArgumentException("Invalid media type: $type");
+        }
+
+        $media = new Media(
+            Uuid::uuid4()->toString(),
+            $type,
+            $title,
+            $description,
+            $sourceUrl,
+            new DateTimeImmutable(),
+            $metadata
+        );
+
+        $this->repository->save($media);
+
+        return $media;
+    }
+
+    public function searchByType(string $type): array
+    {
+        return $this->repository->findByType($type);
+    }
+
+    public function searchByTitle(string $title): array
+    {
+        return $this->repository->findByTitle($title);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "ramsey/uuid": "^4.9"
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
@@ -17,6 +18,7 @@
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
+        "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^10.5",
         "spatie/laravel-ignition": "^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75f7806c2c116ffafd35e37a952f1b30",
+    "content-hash": "920b0d64de752f4bb0f97c005f82e243",
     "packages": [
         {
             "name": "brick/math",
@@ -6346,6 +6346,64 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "578fa296a166605d97b94091f724f1257185d278"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578fa296a166605d97b94091f724f1257185d278",
+                "reference": "578fa296a166605d97b94091f724f1257185d278",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-19T08:58:49+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/storage/media.json.example
+++ b/storage/media.json.example
@@ -1,0 +1,42 @@
+{
+    "608a622c-36bc-4215-9e81-82b7ae860072": {
+        "uuid": "608a622c-36bc-4215-9e81-82b7ae860072",
+        "type": "image",
+        "title": "Logo",
+        "description": "Example logo",
+        "sourceUrl": "http:\/\/example.com\/logo.png",
+        "uploadedAt": "2025-09-21T23:58:12+00:00",
+        "metadata": {
+            "width": "1920",
+            "height": "1080",
+            "format": "png"
+        }
+    },
+    "a4d439a3-1666-4cca-aa35-94ca5b7306ad": {
+        "uuid": "a4d439a3-1666-4cca-aa35-94ca5b7306ad",
+        "type": "image",
+        "title": "Logo",
+        "description": "Company logo",
+        "sourceUrl": "http:\/\/example.com\/logo.png",
+        "uploadedAt": "2025-09-22T00:17:27+00:00",
+        "metadata": []
+    },
+    "569c2fbd-b0e4-49d8-b46d-9933e36c6350": {
+        "uuid": "569c2fbd-b0e4-49d8-b46d-9933e36c6350",
+        "type": "video",
+        "title": "Trailer",
+        "description": "Product trailer video",
+        "sourceUrl": "http:\/\/example.com\/trailer.mp4",
+        "uploadedAt": "2025-09-22T00:17:27+00:00",
+        "metadata": []
+    },
+    "d2ec6df3-7cdc-4612-bf87-f5e3ef0e9cb0": {
+        "uuid": "d2ec6df3-7cdc-4612-bf87-f5e3ef0e9cb0",
+        "type": "audio",
+        "title": "Podcast",
+        "description": "Tech podcast",
+        "sourceUrl": "http:\/\/example.com\/podcast.mp3",
+        "uploadedAt": "2025-09-22T00:17:27+00:00",
+        "metadata": []
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces the initial **Media Module** for the Modular CMS challenge.  
It implements core functionality for media storage, metadata enrichment, and search using a JSON file as persistence layer.

---

## Changes

- Added `Media` entity (POPO).
- Added `MediaRepositoryInterface`.
- Added `InMemoryMediaRepository` for testing and `FileMediaRepository` for JSON persistence.
- Implemented `MediaService` (creation, validation, search).
- Implemented `MediaMetadataService` (metadata enrichment).
- Created Artisan commands:
  - `media:upload` → create and store media entries.
  - `media:enrich` → add or update metadata.
  - `media:search` → search by type or title.
- Added `storage/media.json` as persistence file.

---

## Usage Examples

- Upload media:
  ```bash
  php artisan media:upload image "Logo" "Company logo" "http://example.com/logo.png"
````

* Enrich metadata:

  ```bash
  php artisan media:enrich <uuid> width=1920 height=1080 format=png
  ```

* Search by type:

  ```bash
  php artisan media:search --type=image
  ```